### PR TITLE
Mapeamento de testes no código e readme

### DIFF
--- a/Docs/plano_testes.md
+++ b/Docs/plano_testes.md
@@ -1,0 +1,99 @@
+# Plano de Testes - MarcaAguaTexto
+
+Este documento apresenta o mapeamento completo dos testes realizados para o projeto **MarcaAguaTexto**, desenvolvido no âmbito da unidade curricular **Laboratório de Desenvolvimento de Software** (Licenciatura em Engenharia Informática, Universidade Aberta).
+
+O plano de testes inclui testes de caixa fechada, caixa aberta, integração de cima para baixo, integração de baixo para cima e testes de explosão.
+
+---
+
+## 🔧 Testes Dinâmicos Unitários de Caixa Fechada
+
+| ID    | Criado | Descrição                                           | Dados de Input                          | Resultado Esperado                                   | Notas |
+|-------|--------|--------------------------------------------------------|-----------------------------------------|------------------------------------------------------|-------|
+| CF001 | ✅ | Verificar mensagem final | Texto e número válidos | View apresenta confirmação no final | Foi testado a apresentação da confirmação após codificação com sucesso |
+| CF002 | ✅ | Executar programa com texto válido e 50 destinatários | Texto com >=50 espaços, número=50 | Ficheiros criados com marca de água | Foi testado a geração de vários ficheiros corretamente |
+| CF003 | ✅ | Executar programa com texto inválido | Texto sem espaços, número=5 | Mensagem de erro para o utilizador | Foi testado mensagens de erro para texto inválido (ex: sem espaços) |
+| CF004 | ❌ | Testar número de destinatários inferior a 1 | Número = 0 | Apresenta erro / bloqueio |   |
+| CF005 | ❌ | Validar inserção correta do marcador de início e fim (sequência 511) | Texto válido | Verificar que o binário com sequência de 9 bits de 1 está inserido |   |
+| CF006 | ❌ | Validar aplicação correta do CRC-8 | Texto e número válidos | Ficheiros contêm código CRC-8 no fim da codificação |   |
+| CF007 | ❌ | Validar codificação correta dos espaços e espaços ininterruptos | Texto e número válidos | Espaços simples são 0, espaços ininterruptos são 1 |   |
+| CF008 | ❌ | Gerar ficheiros corretamente para exatamente 510 destinatários | Número = 510 | 510 ficheiros criados com marca de água correta |   |
+| CF009 | ❌ | Texto insuficiente para codificação de todos os destinatários | Texto com poucos espaços, número alto | Apresentar erro de codificação |   |
+
+---
+
+## 🔧 Testes Dinâmicos Unitários de Caixa Aberta
+
+| ID    | Criado | Descrição                                           | Dados de Input                          | Resultado Esperado                                   | Notas |
+|-------|--------|--------------------------------------------------------|-----------------------------------------|------------------------------------------------------|-------|
+| CA001 | ✅ | Validar texto com espaços suficientes | Texto com mais de 100 espaços; número=100 | Retorna True | Validação de número mínimo de espaços foi testada |
+| CA002 | ✅ | Validar texto com espaços insuficientes | Texto com menos de 10 espaços; número=10 | Retorna False |   |
+| CA003 | ✅ | Validar número de destinatários acima do limite | Texto válido; número=1000 | Retorna False |   |
+| CA004 | ✅ | Converter número válido para binário | Número = 42 | Retorna "000101010" |   |
+| CA005 | ✅ | Converter número mínimo para binário | Número = 0 | Retorna "000000000" |   |
+| CA006 | ✅ | Lançar erro ao converter número inválido (-1) | Número = -1 | Gera erro do tipo ValueError |   |
+| CA007 | ✅ | Lançar erro ao converter número inválido (limite++) | Número = limite++ | Gera erro do tipo ValueError |   |
+| CA008 | ✅ | Gerar CRC-8 de string binária | Binário = "000101010" | Retorna string de 8 bits (ex: "10101010") | Acho que não errei, isto é 8bits, certo? |
+| CA009 | ✅ | Criar e validar ficheiro de saída | Nenhum (só cria o ficheiro) | criar_ficheiro() e validar_ficheiro() retornam True |   |
+| CA010 | ✅ | Escrever e validar escrita em ficheiro | Texto com 3 linhas | escrever_ficheiro() e validar_escrita() retornam True |   |
+| CA011 | ✅ | Codificar texto com binário válido | Texto com >= 40 espaços, binário de 9 bits | Retorna string com mesmo comprimento |   |
+| CA012 | ✅ | Erro ao codificar texto com poucos espaços | Texto com 5 espaços, binário de 9 bits | Gera erro do tipo ValueError |   |
+| CA013 | ❌ | Validar dados com texto vazio | texto = [], numero = 5 | Retorna False |   |
+| CA014 | ❌ | Validar texto com apenas espaços em branco | Texto com " " (vários espaços seguidos) | Retorna True | Não sei como será suposto reagir, mas assumo que seja para dar erro? AP - Diria que retorna true porque é possível codificar os espaços |
+| CA015 | ❌ | Tentar escrever ficheiro sem texto definido no model | model.texto_original = [], depois escrever_ficheiro() | Retorna False ou lança exceção |   |
+| CA016 | ❌ | Codificar texto com número de espaços igual ao necessário | Texto com 9 espaços, binário com 9 bits | Retorna texto com todos os espaços substituídos |   |
+| CA017 | ❌ | Codificar texto com caracteres especiais | Texto com acentos, emojis, símbolos; número = 5 | Codificação é bem-sucedida ou erro esperado | Garante compatibilidade com UTF-8 |
+
+---
+
+## 🔧 Testes de Integração de Cima para Baixo
+
+| ID    | Criado | Descrição                                           | Dados de Input                          | Resultado Esperado                                   | Notas |
+|-------|--------|--------------------------------------------------------|-----------------------------------------|------------------------------------------------------|-------|
+| CB001 | ❌ | Chamada ao controller.iniciar_programa() | Texto válido, número=30 | Fluxo completo de codificação executado |   |
+| CB002 | ❌ | Controller chama Model e View | Componente Controller inicializa ambos | Ficheiro criado sem exceções |   |
+| CB003 | ❌ | Controller gere erro do Model | Texto inválido (poucos espaços) | Mensagem de erro sem crash |   |
+
+
+---
+
+## 🔧 Testes de Integração de Baixo para Cima
+
+| ID    | Criado | Descrição                                           | Dados de Input                          | Resultado Esperado                                   | Notas |
+|-------|--------|--------------------------------------------------------|-----------------------------------------|------------------------------------------------------|-------|
+| BC001 | ✅ | Validar dados e criar ficheiro (Model) | Texto com espaços e número viável | Validação = True; ficheiro é criado |   |
+| BC002 | ✅ | Escrever texto e validar escrita no ficheiro (Model) | Texto com várias linhas | Escrita e validação retornam True |   |
+| BC003 | ✅ | Codificar texto com binário válido (Encoding) | Texto com >= 40 espaços, binário com 9 bits | Codificação retorna string do mesmo comprimento |   |
+| BC004 | ✅ | Codificação falha com poucos espaços (Encoding) | Texto com 5 espaços, binário com 9 bits | Gera erro do tipo ValueError |   |
+| BC005 | ❌ | Validar dados no Model -> Usar no View | Texto válido, número=20 | View aceita dados para codificação |   |
+| BC006 | ❌ | Model retorna True -> Controller executa codificação | Texto válido e número=100 | Codificação binária executada |   |
+| BC007 | ❌ | Codificação válida -> Geração do ficheiro final | Binário e CRC válidos | Ficheiro é criado com texto alterado |   |
+
+---
+
+## 🔧 Testes de Explosão (Big Bang)
+
+| ID    | Criado | Descrição                                           | Dados de Input                          | Resultado Esperado                                   | Notas |
+|-------|--------|--------------------------------------------------------|-----------------------------------------|------------------------------------------------------|-------|
+| EX001 | ❌ | Executar main.py com input completo | Texto com 300 espaços, número=300 | Ficheiro com marca de água criado |   |
+| EX002 | ❌ | Injetar falha na View durante execução | Mock impede View de apresentar mensagem | Exceção tratada, aplicação não encerra abruptamente |   |
+| EX003 | ❌ | Executar sistema completo com dados reais | Texto realista, número=200 | Texto final com marca embutida |   |
+| EX004 | ❌ | Verificar comportamento com erro em ficheiro durante execução global | Texto válido, mas erro ao escrever ficheiro | Erro tratado sem crash |   |
+
+---
+
+## 💡 Notas adicionais
+
+- A criação de ambiente virtual (venv) é recomendada para isolar dependências.
+- A execução dos testes pode ser realizada com:
+
+```bash
+python -m pytest MarcaAguaTexto/tests/
+```
+
+---
+
+## 📈 Estado dos Testes
+
+- ✅ Testes criados e validados: 3
+- ❌ Testes pendentes de criação: 34

--- a/MarcaAguaTexto/tests/test_controller/descodificador.py
+++ b/MarcaAguaTexto/tests/test_controller/descodificador.py
@@ -72,4 +72,8 @@ def ler_marca_agua_interpretar_validar_crc(ficheiro_txt):
 if __name__ == "__main__":
     ler_marca_agua_interpretar_validar_crc("../../destinatario_0.txt")
 
+def test_descodificador_leitura_crc():
+    # CF006: Validar aplicação correta do CRC-8 na descodificação
+    ler_marca_agua_interpretar_validar_crc("../../destinatario_0.txt")
+
 

--- a/MarcaAguaTexto/tests/test_controller/test_controller_methods.py
+++ b/MarcaAguaTexto/tests/test_controller/test_controller_methods.py
@@ -15,16 +15,20 @@ import MarcaAguaTexto.Controller.wmk_controller_encoding
 
 # Teste para a convers�o do n�mero do destin�rio no c�digo bin�rio
 def test_binary_converter():
+    # CA004: Converter número válido para binário
     pass
 
 # Teste para gerar o c�digo CRC-8 a partir de uma string bin�ria
 def test_error_detection():
+    # CF006: Validar aplicação correta do CRC-8
     pass
 
 # Teste para a subsituir os espa�os por texto por espa�os ou espa�os ininterruptos
 def test_encode_binary_into_text():
+    # CF007: Validar codificação correta dos espaços e espaços ininterruptos
     pass
 
 # Teste para a codifica��o do texto
 def test_codificar_texto():
+    # CA011: Codificar texto com binário válido
     pass

--- a/MarcaAguaTexto/tests/test_controller/test_wmk_controller_encoding.py
+++ b/MarcaAguaTexto/tests/test_controller/test_wmk_controller_encoding.py
@@ -20,17 +20,22 @@ def encoder():
     return WmkControllerEncoding()
 
 def test_binary_converter_valido(encoder):
+    # CA004: Converter número válido para binário
+    # CA005: Converter número mínimo para binário (0)
     assert encoder.binary_converter(0) == "000000000"
     assert encoder.binary_converter(42) == "000101010"
     assert encoder.binary_converter(510) == "111111110"
 
 def test_binary_converter_invalido(encoder):
+    # CA006: Lançar erro ao converter número inválido (-1)
+    # CA007: Lançar erro ao converter número inválido (limite++)
     with pytest.raises(ValueError):
         encoder.binary_converter(-1)
     with pytest.raises(ValueError):
         encoder.binary_converter(511)
 
 def test_error_detection_output(encoder):
+    # CF006: Validar aplicação correta do CRC-8
     binario = "000101010"
     crc = encoder.error_detection(binario)
     assert isinstance(crc, str)
@@ -38,6 +43,7 @@ def test_error_detection_output(encoder):
     assert all(c in "01" for c in crc)
 
 def test_encode_binary_into_text_sucesso(encoder):
+    # CF007: Validar codificação correta dos espaços e espaços ininterruptos
     texto = "A " * 40  # 40 espaços
     binario = encoder.binary_converter(42)
     codificado = encoder.encode_binary_into_text(texto, binario)
@@ -45,6 +51,7 @@ def test_encode_binary_into_text_sucesso(encoder):
     assert len(codificado) == len(texto)
 
 def test_encode_binary_into_text_erro(encoder):
+    # CA012: Erro ao codificar texto com poucos espaços
     texto = "A " * 5  # poucos espaços
     binario = encoder.binary_converter(42)
     with pytest.raises(ValueError):

--- a/MarcaAguaTexto/tests/test_main.py
+++ b/MarcaAguaTexto/tests/test_main.py
@@ -18,4 +18,5 @@ import MarcaAguaTexto.main
 
 # Teste para inciar programa
 def test_main():
+    # CB001: Chamada ao controller.iniciar_programa() - fluxo completo de codificação executado
     pass

--- a/MarcaAguaTexto/tests/test_model.py
+++ b/MarcaAguaTexto/tests/test_model.py
@@ -3,6 +3,7 @@ import pytest
 from MarcaAguaTexto.Model.model import Model
 
 def test_validar_dados_valido():
+    # CA001: Validar texto com espaços suficientes
     texto = [
         "linha 1 com espaços entre palavras para testar corretamente a funcionalidade e passar no teste com mais de trinta e cinco espaços.",
         "linha 2 ainda mais espaços para garantir que temos mais que suficiente no total, mesmo que o texto não faça muito sentido."
@@ -12,24 +13,28 @@ def test_validar_dados_valido():
     assert modelo.validar_dados(texto, num_destinatarios) is True
 
 def test_validar_dados_excesso_destinatarios():
+    # CA003: Validar número de destinatários acima do limite
     texto = ["texto com espaços suficientes"]
     num_destinatarios = 1000
     modelo = Model()
     assert modelo.validar_dados(texto, num_destinatarios) is False
 
 def test_validar_dados_poucos_espacos():
+    # CA002: Validar texto com espaços insuficientes
     texto = ["sem_espacos"]
     num_destinatarios = 10
     modelo = Model()
     assert modelo.validar_dados(texto, num_destinatarios) is False
 
 def test_criar_e_validar_ficheiro():
+    # CA009: Criar e validar ficheiro de saída
     modelo = Model()
     assert modelo.criar_ficheiro() is True
     assert modelo.validar_ficheiro() is True
     os.remove("saida_marca_agua.txt")
 
 def test_escrever_e_validar_escrita():
+    # CA010: Escrever e validar escrita em ficheiro
     texto = ["linha 1", "linha 2", "linha 3"]
     modelo = Model(texto=texto)
     modelo.criar_ficheiro()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
 # MarcaAguaTexto
+
+Projeto de simulação empresarial desenvolvido no âmbito da unidade curricular **Laboratório de Desenvolvimento de Software** (Licenciatura em Engenharia Informática, Universidade Aberta – Portugal).
+
+O objetivo deste projeto é desenvolver uma aplicação capaz de introduzir uma marca de água não visível ao olho humando em ficheiros de texto.
+
+---
+
+## 📚 Sobre o Projeto
+
+A aplicação implementa um fluxo básico de manipulação de texto, onde:
+
+- Recebe um texto e o número de destinatários.
+- Converte o número em binário de 9 bits.
+- Calcula um CRC-8 para validação.
+- Codifica o texto original embutindo a marca de água.
+- Gera um novo ficheiro de saída com a marca embutida.
+
+O projeto está organizado segundo o padrão **MVC (Model-View-Controller)**:
+
+- **Model**: Gere os dados (texto original, texto codificado, operações de validação e gravação).
+- **View**: Responsável pela interação com o utilizador (input/output).
+- **Controller**: Faz a ligação entre o Model e a View, coordenando a lógica do programa.
+
+---
+
+## 💪 Tecnologias utilizadas
+
+- Python 3.10+
+- Pytest (para testes automatizados)
+- CRCMod (para geração de CRC-8)
+- tkinter (Python interface)
+- Estrutura modular (MVC)
+
+---
+
+## 🚀 Como correr o projeto
+
+1. Clonar o repositório:
+
+```bash
+git clone https://github.com/antonina-pereira/MarcaAguaTexto.git
+cd MarcaAguaTexto
+```
+
+2. Criar e ativar um ambiente virtual:
+
+```bash
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+pip install -r MarcaAguaTexto/requirements.txt
+pip install pytest
+$env:PYTHONPATH = "$PWD\MarcaAguaTexto"
+```
+
+3. Executar o programa:
+
+```bash
+python -m MarcaAguaTexto.main
+```
+
+4. Executar os testes:
+
+```bash
+python -m pytest MarcaAguaTexto/tests/
+```
+
+---
+
+## 📂 Estrutura do Projeto
+
+```
+MarcaAguaTexto/
+│
+├── Controller/          # Lógica de controlo
+│   └── utils/           # Utilitários como CRC
+│
+├── Model/               # Manipulação de dados (texto e marca de água)
+│
+├── View/                # Interação com o utilizador (CLI)
+│
+├── tests/               # Testes automatizados (Pytest)
+│
+├── Saida/               # Pasta para ficheiros de saída gerados
+│
+├── Docs/               # Pasta para documentação
+│
+└── main.py              # Ponto de entrada do programa
+```
+
+---
+
+## 🔪 Testes
+
+O projeto inclui testes de:
+
+- Caixa aberta
+- Caixa fechada
+- Integração de baixo para cima
+- Integração de cima para baixo
+- Testes de explosão
+
+Todos os testes encontram-se documentados em [`docs/plano_testes.md`](docs/plano_testes.md), onde cada ID corresponde a um comentário associado no respetivo código de testes.
+
+Para correr todos os testes:
+
+```bash
+python -m pytest MarcaAguaTexto/tests/
+```
+
+---
+
+## 📜 Notas
+
+- A pasta `saida/` é mantida no repositório com um ficheiro `.gitkeep` para garantir a sua presença.
+- A pasta `venv/` é ignorada pelo controlo de versões.
+- O projeto foi desenvolvido no âmbito da metodologia e-SimProgramming, num ambiente de simulação de empresa onde os estudantes assumem o papel de estagiários recentemente contratados pela empresa fictícia SimProgramming, seguindo práticas profissionais de desenvolvimento colaborativo e aprendizagem baseada em problemas.


### PR DESCRIPTION
- Mapeamento de todos os testes existentes no código, associando cada ID nos comentários dos ficheiros de testes.
- Criação de um ficheiro docs/plano_testes.md com o plano de testes completo, convertido diretamente do ficheiro Excel original. A ideia é centralizar a informação toda no git e termos maior visibilidade sobre as alterações.
- Criação de um README.md. Não coloquei os nossos nomes porque há pessoas com alias aqui no git e poderiam não concordam. Caso concordem, penso que fará sentido colocar os nomes e cargos.

Sintam-se à vontade para modificar :)